### PR TITLE
Refactor single cell files and arguments

### DIFF
--- a/1.generate-profiles/0.merge-single-cells.py
+++ b/1.generate-profiles/0.merge-single-cells.py
@@ -22,16 +22,10 @@ parser.add_argument(
     default="profiling_config.yaml",
 )
 parser.add_argument(
-    "--single_file_only",
-    help="add flag to output all single cell profiles merged into one output file",
-    action="store_true",
-)
-parser.add_argument(
     "--force", help="force overwriting of single cell data", action="store_true"
 )
 args = parser.parse_args()
 config_file = args.config_file
-single_file_only = args.single_file_only
 force = args.force
 
 config = process_config_file(config_file)
@@ -44,6 +38,7 @@ single_cell_args = config["single_cell"]
 project = master_args["project_tag"]
 batch = core_args["batch"]
 batch_dir = core_args["batch_dir"]
+single_file_only = core_args["output_one_single_cell_file_only"]
 compartments = core_args["compartments"]
 parent_col_info = core_args["parent_cols"]
 id_cols = core_args["id_cols"]
@@ -129,7 +124,7 @@ for site in sites:
 
     if len(compartment_csvs) != len(compartments):
         warnings.warn(
-            f"Not all compartments are present in site: {site}\nCheck CellProfiler output path: {site_compartment_dir}"
+            f"Not all compartments are present in site: {site}\nCheck CellProfiler output path: {site_compartment_dir}. Skipping this site."
         )
         continue
 

--- a/1.generate-profiles/profiling_config.yaml
+++ b/1.generate-profiles/profiling_config.yaml
@@ -10,6 +10,7 @@ core:
   site_dir: ../0.preprocess-sites/data/
   output_single_cell_dir: single_cell/
   output_profile_dir: profiles/
+  output_one_single_cell_file_only: false
   categorize_cell_quality: simple
   compression: gzip
   float_format: "%.5g"
@@ -53,8 +54,6 @@ single_cell:
 ---
 aggregate:
   perform: true
-  from_single_file: true
-  from_site_files: false
   output_basedir: data/profiles
   operation: median
   features: infer

--- a/scripts/config_utils.py
+++ b/scripts/config_utils.py
@@ -22,7 +22,11 @@ def make_batch_path(config, load_data=True):
     master = config["master_config"]
     core = config["core"]
     batch_dir = pathlib.Path(
-        core["project_dir"], master["project_tag"], "workspace", "analysis", core["batch"],
+        core["project_dir"],
+        master["project_tag"],
+        "workspace",
+        "analysis",
+        core["batch"],
     )
     return batch_dir
 
@@ -55,18 +59,17 @@ def generate_profiles_config(config):
     batch_dir = make_batch_path(config, load_data=False)
     config["core"]["batch_dir"] = batch_dir
     batch = config["core"]["batch"]
+    site_dir = config["core"]["site_dir"]
+    ignore_files = config["core"]["ignore_files"]
+
     # Build paths to single cell yaml document of the profiling pipeline
     config["single_cell"]["prefilter_file"] = pathlib.Path(
-        config["core"]["site_dir"], batch, "feature_prefilter.tsv"
+        site_dir, batch, "feature_prefilter.tsv"
     )
 
-    config["single_cell"]["spot_metadata_dir"] = pathlib.Path(
-        config["core"]["site_dir"], batch, "spots"
-    )
+    config["single_cell"]["spot_metadata_dir"] = pathlib.Path(site_dir, batch, "spots")
 
-    config["single_cell"]["paint_metadata_dir"] = pathlib.Path(
-        config["core"]["site_dir"], batch, "paint"
-    )
+    config["single_cell"]["paint_metadata_dir"] = pathlib.Path(site_dir, batch, "paint")
 
     config["single_cell"]["single_cell_output_dir"] = pathlib.Path(
         config["single_cell"]["output_basedir"], batch
@@ -78,10 +81,39 @@ def generate_profiles_config(config):
         f"{batch}_single_cell_profiles.csv.gz",
     )
 
+    # Build single cell site files
+    sites = [
+        x.name
+        for x in config["single_cell"]["spot_metadata_dir"].iterdir()
+        if x.name not in ignore_files
+    ]
+
+    config["single_cell"]["site_files"] = {}
+    for site in sites:
+        # Define single cell output directory and files
+        site_output_dir = pathlib.Path(
+            config["single_cell"]["single_cell_output_dir"], site
+        )
+        config["single_cell"]["site_files"][site] = pathlib.Path(
+            site_output_dir, f"{site}_single_cell.csv.gz"
+        )
+
     # Build paths to aggregate yaml document
     config["aggregate"]["aggregate_output_dir"] = pathlib.Path(
         config["aggregate"]["output_basedir"], batch
     )
+
+    # Build aggregated output files
+    config["aggregate"]["aggregate_output_files"] = {}
+    for aggregate_level, aggregate_columns in config["aggregate"]["levels"].items():
+        config["aggregate"]["aggregate_output_files"][aggregate_level] = pathlib.Path(
+            config["aggregate"]["aggregate_output_dir"],
+            f"{batch}_{aggregate_level}.csv.gz",
+        )
+
+    config["aggregate"]["aggregate_output_files"]["single_cell"] = config[
+        "single_cell"
+    ]["single_file_only_output_file"]
 
     return config
 


### PR DESCRIPTION
Two interconnected updates in this PR

* I remove the option for a user to produce _both_ one single cell file _and_ site-level specific single cell files. The user now has an either-or option. The user is probably limited to site-level specific files when there are tons of sites (like in our whole genome experiments)
* I move file generation to the config utils

In general, the philosophy of the last bullet point is summarized by: **lets move all file and directory manipulation to the config file**. Because data is flowing between scripts, it makes sense to define the outputs (and subsequently, the inputs!) only once. 

I make these updates only in the `1.generate-profiles` module.