### PR TITLE
Add step arguments to all recipe scripts

### DIFF
--- a/0.preprocess-sites/0.prefilter-features.py
+++ b/0.preprocess-sites/0.prefilter-features.py
@@ -31,6 +31,7 @@ experiment_config_file = args.experiment_config_file
 
 config = process_configuration(
     plate_id,
+    step="preprocess--prefilter",
     options_config=options_config_file,
     experiment_config=experiment_config_file,
 )

--- a/0.preprocess-sites/1.process-spots.py
+++ b/0.preprocess-sites/1.process-spots.py
@@ -64,6 +64,7 @@ experiment_config_file = args.experiment_config_file
 
 config = process_configuration(
     plate_id,
+    step="preprocess--process-spots",
     options_config=options_config_file,
     experiment_config=experiment_config_file,
 )

--- a/0.preprocess-sites/2.process-cells.py
+++ b/0.preprocess-sites/2.process-cells.py
@@ -40,6 +40,7 @@ experiment_config_file = args.experiment_config_file
 
 config = process_configuration(
     plate_id,
+    step="preprocess--process-cells",
     options_config=options_config_file,
     experiment_config=experiment_config_file,
 )

--- a/0.preprocess-sites/3.visualize-cell-summary.py
+++ b/0.preprocess-sites/3.visualize-cell-summary.py
@@ -24,6 +24,7 @@ experiment_config_file = args.experiment_config_file
 
 config = process_configuration(
     plate_id,
+    step="preprocess--summarize-cells",
     options_config=options_config_file,
     experiment_config=experiment_config_file,
 )

--- a/0.preprocess-sites/4.image-and-segmentation-qc.py
+++ b/0.preprocess-sites/4.image-and-segmentation-qc.py
@@ -21,6 +21,7 @@ experiment_config_file = args.experiment_config_file
 
 config = process_configuration(
     plate_id,
+    step="preprocess--summarize-plate",
     options_config=options_config_file,
     experiment_config=experiment_config_file,
 )

--- a/1.generate-profiles/0.merge-single-cells.py
+++ b/1.generate-profiles/0.merge-single-cells.py
@@ -27,6 +27,7 @@ experiment_config_file = args.experiment_config_file
 
 config = process_configuration(
     plate_id,
+    step="profile--single_cell",
     options_config=options_config_file,
     experiment_config=experiment_config_file,
 )

--- a/1.generate-profiles/1.aggregate.py
+++ b/1.generate-profiles/1.aggregate.py
@@ -19,6 +19,7 @@ experiment_config_file = args.experiment_config_file
 
 config = process_configuration(
     plate_id,
+    step="profile--aggregate",
     options_config=options_config_file,
     experiment_config=experiment_config_file,
 )

--- a/1.generate-profiles/2.normalize.py
+++ b/1.generate-profiles/2.normalize.py
@@ -18,6 +18,7 @@ experiment_config_file = args.experiment_config_file
 
 config = process_configuration(
     plate_id,
+    step="profile--normalize",
     options_config=options_config_file,
     experiment_config=experiment_config_file,
 )

--- a/1.generate-profiles/3.feature-select.py
+++ b/1.generate-profiles/3.feature-select.py
@@ -18,6 +18,7 @@ experiment_config_file = args.experiment_config_file
 
 config = process_configuration(
     plate_id,
+    step="profile--feature_select",
     options_config=options_config_file,
     experiment_config=experiment_config_file,
 )


### PR DESCRIPTION
Note that the step names directly correspond to the `options.yaml` file.

This is a necessary step to fix broadinstitute/pooled-cell-painting-profiling-template#22