### PR TITLE
add a configurable chunksize whenever loading

### DIFF
--- a/0.preprocess-sites/1.process-spots.py
+++ b/0.preprocess-sites/1.process-spots.py
@@ -54,7 +54,7 @@ from utils import parse_command_args, process_configuration, get_split_aware_sit
 recipe_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.append(os.path.join(recipe_path, "scripts"))
 from cell_quality_utils import CellQuality
-from io_utils import check_if_write
+from io_utils import check_if_write, read_csvs_with_chunksize
 
 args = parse_command_args()
 
@@ -134,7 +134,7 @@ for data_split_site in site_info_dict:
         # Load image metadata per site
         try:
             image_file = pathlib.Path(input_batchdir, site, "Image.csv")
-            image_df = pd.read_csv(image_file).assign(
+            image_df = read_csvs_with_chunksize(image_file).assign(
                 Metadata_site=site, Metadata_dataset_split=data_split_site
             )
             image_list.append(image_df)
@@ -150,10 +150,10 @@ for data_split_site in site_info_dict:
         # Load spot data
         try:
             barcode_file = pathlib.Path(input_batchdir, site, "BarcodeFoci.csv")
-            barcodefoci_df = pd.read_csv(barcode_file)
+            barcodefoci_df = read_csvs_with_chunksize(barcode_file)
 
             foci_file = pathlib.Path(input_batchdir, site, "Foci.csv")
-            foci_df = pd.read_csv(foci_file)
+            foci_df = read_csvs_with_chunksize(foci_file)
         except FileNotFoundError:
             print(f"{site} data not found")
             continue

--- a/0.preprocess-sites/2.process-cells.py
+++ b/0.preprocess-sites/2.process-cells.py
@@ -30,7 +30,7 @@ recipe_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.append(os.path.join(recipe_path, "scripts"))
 from cell_quality_utils import CellQuality
 from paint_utils import load_single_cell_compartment_csv, merge_single_cell_compartments
-from io_utils import check_if_write
+from io_utils import check_if_write, read_csvs_with_chunksize
 
 args = parse_command_args()
 
@@ -95,7 +95,7 @@ cell_category_df = pd.DataFrame(cell_category_dict, index=[quality_col]).transpo
 # Enables feature filtering by loading the Cell Painting feature file.
 # 0.prefilter-features.py must be run first
 try:
-    all_feature_df = pd.read_csv(prefilter_file, sep="\t").query("not prefilter_column")
+    all_feature_df = read_csvs_with_chunksize(prefilter_file, sep="\t").query("not prefilter_column")
 except FileNotFoundError:
     raise FileNotFoundError(
         "Error",
@@ -106,7 +106,7 @@ except FileNotFoundError:
 # Load image metadata summary file to extract out important metadata indicators
 # 1.process-spots.py must be run first
 try:
-    image_df = pd.read_csv(input_image_file, sep="\t")
+    image_df = read_csvs_with_chunksize(input_image_file, sep="\t")
 except FileNotFoundError:
     raise FileNotFoundError(
         "Error",
@@ -151,7 +151,7 @@ for data_split_site in site_info_dict:
                 foci_dir, site, "cell_id_barcode_alignment_scores_by_guide.tsv.gz"
             )
             try:
-                foci_df = pd.read_csv(foci_file, sep="\t")
+                foci_df = read_csvs_with_chunksize(foci_file, sep="\t")
             except FileNotFoundError:
                 print(
                     """Run 1.process-spots before continuing. \n

--- a/0.preprocess-sites/2.process-cells.py
+++ b/0.preprocess-sites/2.process-cells.py
@@ -95,7 +95,9 @@ cell_category_df = pd.DataFrame(cell_category_dict, index=[quality_col]).transpo
 # Enables feature filtering by loading the Cell Painting feature file.
 # 0.prefilter-features.py must be run first
 try:
-    all_feature_df = read_csvs_with_chunksize(prefilter_file, sep="\t").query("not prefilter_column")
+    all_feature_df = read_csvs_with_chunksize(prefilter_file, sep="\t").query(
+        "not prefilter_column"
+    )
 except FileNotFoundError:
     raise FileNotFoundError(
         "Error",
@@ -202,7 +204,10 @@ for data_split_site in site_info_dict:
         # Add the cell quality metadata to the df
         metadata_df = (
             metadata_df.merge(
-                cell_category_df, left_on=quality_idx, right_index=True, how="left",
+                cell_category_df,
+                left_on=quality_idx,
+                right_index=True,
+                how="left",
             )
             .sort_values(by=cell_sort_col)
             .drop_duplicates(subset=[cell_sort_col, quality_idx])

--- a/0.preprocess-sites/3.visualize-cell-summary.py
+++ b/0.preprocess-sites/3.visualize-cell-summary.py
@@ -227,7 +227,9 @@ total_cell_count_gg = (
     + gg.ggtitle(f"{all_cells} Total Cells")
     + gg.facet_wrap("~Metadata_dataset_split", drop=False, scales="free_x")
     + gg.scale_fill_manual(
-        name="Cell Quality", labels=cell_category_order, values=cell_category_colors,
+        name="Cell Quality",
+        labels=cell_category_order,
+        values=cell_category_colors,
     )
 )
 
@@ -251,7 +253,9 @@ total_cell_well_count_gg = (
     + gg.ylab("Cell Count")
     + gg.facet_wrap("~Cell_Quality")
     + gg.scale_fill_manual(
-        name="Cell Quality", labels=cell_category_order, values=cell_category_colors,
+        name="Cell Quality",
+        labels=cell_category_order,
+        values=cell_category_colors,
     )
     + gg.theme(strip_background=gg.element_rect(colour="black", fill="#fdfff4"))
 )

--- a/0.preprocess-sites/3.visualize-cell-summary.py
+++ b/0.preprocess-sites/3.visualize-cell-summary.py
@@ -14,7 +14,7 @@ from utils import parse_command_args, process_configuration, get_split_aware_sit
 recipe_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.append(os.path.join(recipe_path, "scripts"))
 from cell_quality_utils import CellQuality
-from io_utils import check_if_write
+from io_utils import check_if_write, read_csvs_with_chunksize
 
 args = parse_command_args()
 
@@ -99,17 +99,17 @@ for data_split_site in site_info_dict:
         cell_count_file = pathlib.Path(
             f"{input_paintdir}/{site}/cell_counts_{site}.tsv"
         )
-        cell_quality_list.append(pd.read_csv(cell_count_file, sep="\t"))
+        cell_quality_list.append(read_csvs_with_chunksize(cell_count_file, sep="\t"))
 
         # Aggregates site summary stats into a single list
         site_stat_file = pathlib.Path(input_spotdir, site, f"site_stats.tsv")
-        site_stat_list.append(pd.read_csv(site_stat_file, sep="\t"))
+        site_stat_list.append(read_csvs_with_chunksize(site_stat_file, sep="\t"))
 
         # Aggregates perturbation counts by site into a single list
         pert_count_file = pathlib.Path(
             input_spotdir, site, f"cell_perturbation_category_summary_counts.tsv"
         )
-        pert_counts_list.append(pd.read_csv(pert_count_file, sep="\t"))
+        pert_counts_list.append(read_csvs_with_chunksize(pert_count_file, sep="\t"))
 
 # Creates dataframe from cell quality list
 cell_count_df = pd.concat(cell_quality_list, axis="rows").reset_index(drop=True)

--- a/0.preprocess-sites/4.image-and-segmentation-qc.py
+++ b/0.preprocess-sites/4.image-and-segmentation-qc.py
@@ -11,7 +11,7 @@ from utils import parse_command_args, process_configuration
 recipe_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.append(os.path.join(recipe_path, "scripts"))
 from cell_quality_utils import CellQuality
-from io_utils import check_if_write
+from io_utils import check_if_write, read_csvs_with_chunksize
 
 args = parse_command_args()
 
@@ -64,7 +64,7 @@ if not perform:
 if not force:
     force = args.force
 
-cell_count_df = pd.read_csv(cell_count_file, sep="\t")
+cell_count_df = read_csvs_with_chunksize(cell_count_file, sep="\t")
 
 # Creates x, y coordinates for plotting per-plate views.
 # Assumes image numbering starts in upper left corner and proceeds down
@@ -253,7 +253,7 @@ for plate in platelist:
         )
 
 # Load image file
-image_df = pd.read_csv(input_image_file, sep="\t")
+image_df = read_csvs_with_chunksize(input_image_file, sep="\t")
 image_meta_col_list = list(image_cols.values())
 
 # Add in x, y coordinates for plotting

--- a/0.preprocess-sites/4.image-and-segmentation-qc.py
+++ b/0.preprocess-sites/4.image-and-segmentation-qc.py
@@ -249,7 +249,9 @@ for plate in platelist:
     )
     if check_if_write(output_file, force, throw_warning=True):
         empty_gg.save(
-            output_file, dpi=300, verbose=False,
+            output_file,
+            dpi=300,
+            verbose=False,
         )
 
 # Load image file
@@ -273,7 +275,9 @@ image_df_subset = image_df.dropna(subset=[corr_qc_col])
 for plate in platelist:
     correlation_gg = (
         gg.ggplot(
-            image_df_subset.loc[image_df_subset[image_cols['plate']].str.contains(plate)],
+            image_df_subset.loc[
+                image_df_subset[image_cols["plate"]].str.contains(plate)
+            ],
             gg.aes(x="x_loc", y="y_loc"),
         )
         + gg.geom_point(gg.aes(fill=corr_qc_col), shape="s", size=6)
@@ -312,7 +316,7 @@ for threshhold_compartment in ["Cells", "Nuclei"]:
         compartment_finalthresh_gg = (
             gg.ggplot(
                 image_df_subset.loc[
-                    image_df_subset[image_cols['plate']].str.contains(plate)
+                    image_df_subset[image_cols["plate"]].str.contains(plate)
                 ],
                 gg.aes(x="x_loc", y="y_loc"),
             )
@@ -346,7 +350,7 @@ if confluent_col in image_df.columns:
         percent_confluent_gg = (
             gg.ggplot(
                 image_df_subset.loc[
-                    image_df_subset[image_cols['plate']].str.contains(plate)
+                    image_df_subset[image_cols["plate"]].str.contains(plate)
                 ],
                 gg.aes(x="x_loc", y="y_loc"),
             )
@@ -400,7 +404,7 @@ PLLS_df = PLLS_df.melt(id_vars=image_meta_col_list, var_name="channel").replace(
 for plate in platelist:
     PLLS_gg = (
         gg.ggplot(
-            PLLS_df.loc[PLLS_df[image_cols['plate']].str.contains(plate)],
+            PLLS_df.loc[PLLS_df[image_cols["plate"]].str.contains(plate)],
             gg.aes(x=image_cols["site"], y="value", label=image_cols["site"]),
         )
         + gg.coord_fixed(ratio=0.25)
@@ -519,7 +523,7 @@ if all(x in image_df.columns.tolist() for x in cp_sat_df_cols):
     for plate in platelist:
         cp_saturation_gg = (
             gg.ggplot(
-                cp_sat_df.loc[cp_sat_df[image_cols['plate']].str.contains(plate)],
+                cp_sat_df.loc[cp_sat_df[image_cols["plate"]].str.contains(plate)],
                 gg.aes(x="StdIntensity", y="PercentMax", label=image_cols["site"]),
             )
             + gg.geom_text(size=6)
@@ -592,8 +596,8 @@ if all(x in image_df.columns.tolist() for x in bc_sat_df_cols):
             bc_saturation_gg = (
                 gg.ggplot(
                     bc_sat_df.loc[
-                        (bc_sat_df[image_cols['well']] == well)
-                        & (bc_sat_df[image_cols['plate']] == plate)
+                        (bc_sat_df[image_cols["well"]] == well)
+                        & (bc_sat_df[image_cols["plate"]] == plate)
                     ],
                     gg.aes(x="StdIntensity", y="PercentMax", label=image_cols["site"]),
                 )

--- a/0.preprocess-sites/scripts/site_processing_utils.py
+++ b/0.preprocess-sites/scripts/site_processing_utils.py
@@ -3,6 +3,7 @@ import pandas as pd
 
 from io_utils import read_csvs_with_chunksize
 
+
 def get_compartment_file(compartment, example_dir):
     compartment = compartment.capitalize()
     compart_file = pathlib.PurePath(f"{example_dir}/{compartment}.csv")

--- a/0.preprocess-sites/scripts/site_processing_utils.py
+++ b/0.preprocess-sites/scripts/site_processing_utils.py
@@ -1,6 +1,7 @@
 import pathlib
 import pandas as pd
 
+from io_utils import read_csvs_with_chunksize
 
 def get_compartment_file(compartment, example_dir):
     compartment = compartment.capitalize()
@@ -15,7 +16,7 @@ def load_compartments(core, example_dir):
     for compartment in compartments:
 
         compart_file = get_compartment_file(compartment, example_dir)
-        df = pd.read_csv(compart_file)
+        df = read_csvs_with_chunksize(compart_file)
         df = recode_cols(df, core, compartment)
 
         data[compartment] = df

--- a/0.preprocess-sites/scripts/site_processing_utils.py
+++ b/0.preprocess-sites/scripts/site_processing_utils.py
@@ -1,6 +1,10 @@
 import pathlib
 import pandas as pd
 
+import os
+import sys
+recipe_path = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.append(os.path.join(recipe_path, "scripts"))
 from io_utils import read_csvs_with_chunksize
 
 

--- a/1.generate-profiles/0.merge-single-cells.py
+++ b/1.generate-profiles/0.merge-single-cells.py
@@ -18,6 +18,7 @@ sys.path.append(os.path.join(recipe_path, "scripts"))
 from paint_utils import load_single_cell_compartment_csv, merge_single_cell_compartments
 from cell_quality_utils import CellQuality
 from profile_utils import sanitize_gene_col
+from io_utils import read_csvs_with_chunksize
 
 args = parse_command_args()
 
@@ -82,7 +83,7 @@ if single_file_only:
             )
 
 # Load preselected features
-all_feature_df = pd.read_csv(prefilter_file, sep="\t")
+all_feature_df = read_csvs_with_chunksize(prefilter_file, sep="\t")
 
 if prefilter_features:
     all_feature_df = all_feature_df.query("not prefilter_column")
@@ -127,7 +128,7 @@ for data_split_site in site_info_dict:
 
         # Load cell metadata after cell quality determined in 0.preprocess-sites
         metadata_file = pathlib.Path(site_metadata_dir, f"metadata_{site}.tsv.gz")
-        metadata_df = pd.read_csv(metadata_file, sep="\t").query(
+        metadata_df = read_csvs_with_chunksize(metadata_file, sep="\t").query(
             f"{cell_quality_col} in @cell_filter"
         )
 

--- a/1.generate-profiles/1.aggregate.py
+++ b/1.generate-profiles/1.aggregate.py
@@ -11,6 +11,8 @@ from pycytominer.cyto_utils import output
 sys.path.append("config")
 from utils import parse_command_args, process_configuration, get_split_aware_site_info
 
+recipe_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.append(os.path.join(recipe_path, "scripts"))
 from io_utils import read_csvs_with_chunksize
 
 args = parse_command_args()

--- a/1.generate-profiles/1.aggregate.py
+++ b/1.generate-profiles/1.aggregate.py
@@ -11,6 +11,8 @@ from pycytominer.cyto_utils import output
 sys.path.append("config")
 from utils import parse_command_args, process_configuration, get_split_aware_site_info
 
+from io_utils import read_csvs_with_chunksize
+
 args = parse_command_args()
 
 batch_id = args.batch_id
@@ -75,7 +77,7 @@ for data_split_site in site_info_dict:
     # Load single cell data
     if aggregate_from_single_file:
         print(f"Loading one single cell file: {single_cell_dataset_file}")
-        single_cell_df = pd.read_csv(single_cell_dataset_file, sep=",")
+        single_cell_df = read_csvs_with_chunksize(single_cell_dataset_file, sep=",")
     else:
         sites = site_info_dict[data_split_site]
         print(f"Now loading data from {len(sites)} sites")
@@ -83,7 +85,7 @@ for data_split_site in site_info_dict:
         for site in sites:
             site_file = single_cell_site_files[site]
             if site_file.exists():
-                site_df = pd.read_csv(site_file, sep=",")
+                site_df = read_csvs_with_chunksize(site_file, sep=",")
                 single_cell_df.append(site_df)
             else:
                 warnings.warn(

--- a/1.generate-profiles/2.normalize.py
+++ b/1.generate-profiles/2.normalize.py
@@ -10,6 +10,8 @@ from pycytominer import normalize
 sys.path.append("config")
 from utils import parse_command_args, process_configuration, get_split_aware_site_info
 
+from io_utils import read_csvs_with_chunksize
+
 args = parse_command_args()
 
 batch_id = args.batch_id
@@ -83,7 +85,7 @@ for data_split_site in site_info_dict:
             normalize_output_files[data_level].parents[0],
             output_file.name.replace(".csv.gz", f"_{data_split_site}.csv.gz"),
         )
-        df = pd.read_csv(file_to_normalize)
+        df = read_csvs_with_chunksize(file_to_normalize)
 
         normalize(
             profiles=df,

--- a/1.generate-profiles/2.normalize.py
+++ b/1.generate-profiles/2.normalize.py
@@ -10,6 +10,8 @@ from pycytominer import normalize
 sys.path.append("config")
 from utils import parse_command_args, process_configuration, get_split_aware_site_info
 
+recipe_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.append(os.path.join(recipe_path, "scripts"))
 from io_utils import read_csvs_with_chunksize
 
 args = parse_command_args()

--- a/1.generate-profiles/3.feature-select.py
+++ b/1.generate-profiles/3.feature-select.py
@@ -10,6 +10,8 @@ from pycytominer import feature_select
 sys.path.append("config")
 from utils import parse_command_args, process_configuration, get_split_aware_site_info
 
+recipe_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.append(os.path.join(recipe_path, "scripts"))
 from io_utils import read_csvs_with_chunksize
 
 args = parse_command_args()

--- a/1.generate-profiles/3.feature-select.py
+++ b/1.generate-profiles/3.feature-select.py
@@ -10,6 +10,8 @@ from pycytominer import feature_select
 sys.path.append("config")
 from utils import parse_command_args, process_configuration, get_split_aware_site_info
 
+from io_utils import read_csvs_with_chunksize
+
 args = parse_command_args()
 
 batch_id = args.batch_id
@@ -86,7 +88,7 @@ for data_split_site in site_info_dict:
             feature_select_output_files[data_level].parents[0],
             output_file.name.replace(".csv.gz", f"_{data_split_site}.csv.gz"),
         )
-        df = pd.read_csv(file_to_feature_select)
+        df = read_csvs_with_chunksize(file_to_feature_select)
 
         feature_select(
             profiles=df,

--- a/scripts/io_utils.py
+++ b/scripts/io_utils.py
@@ -14,3 +14,19 @@ def check_if_write(file_path, force, throw_warning=False):
             return False
     else:
         return True
+
+
+def read_csvs_with_chunksize(filename,chunksize=10000,**kwargs):
+    """
+    Read a CSV with an optionally passed chunksize to make reading large files easier.
+    Re-raises any exceptions (likely mostly going to be FileNotFound errors) so they 
+    can continue to be handled how they currently are in the various locations.
+    """
+    try:
+        dflist = []
+        for chunk in pd.read_csv(filename,chunksize=chunksize,**kwargs):
+            dflist.append(chunk)
+        df = pd.concat(dflist)
+        return df
+    except:
+        raise

--- a/scripts/io_utils.py
+++ b/scripts/io_utils.py
@@ -30,6 +30,6 @@ def read_csvs_with_chunksize(filename, chunksize=10000, **kwargs):
             for chunk in reader:
                 dflist.append(chunk)
             df = pd.concat(dflist)
-            return df
+        return df
     except:
         raise

--- a/scripts/io_utils.py
+++ b/scripts/io_utils.py
@@ -1,6 +1,8 @@
 import pathlib
 import warnings
 
+import pandas as pd
+
 
 def check_if_write(file_path, force, throw_warning=False):
     if file_path.exists():
@@ -23,10 +25,11 @@ def read_csvs_with_chunksize(filename, chunksize=10000, **kwargs):
     can continue to be handled how they currently are in the various locations.
     """
     try:
-        dflist = []
-        for chunk in pd.read_csv(filename, chunksize=chunksize, **kwargs):
-            dflist.append(chunk)
-        df = pd.concat(dflist)
-        return df
+        with pd.read_csv(filename, chunksize=chunksize, **kwargs) as reader:
+            dflist = []
+            for chunk in reader:
+                dflist.append(chunk)
+            df = pd.concat(dflist)
+            return df
     except:
         raise

--- a/scripts/io_utils.py
+++ b/scripts/io_utils.py
@@ -16,15 +16,15 @@ def check_if_write(file_path, force, throw_warning=False):
         return True
 
 
-def read_csvs_with_chunksize(filename,chunksize=10000,**kwargs):
+def read_csvs_with_chunksize(filename, chunksize=10000, **kwargs):
     """
     Read a CSV with an optionally passed chunksize to make reading large files easier.
-    Re-raises any exceptions (likely mostly going to be FileNotFound errors) so they 
+    Re-raises any exceptions (likely mostly going to be FileNotFound errors) so they
     can continue to be handled how they currently are in the various locations.
     """
     try:
         dflist = []
-        for chunk in pd.read_csv(filename,chunksize=chunksize,**kwargs):
+        for chunk in pd.read_csv(filename, chunksize=chunksize, **kwargs):
             dflist.append(chunk)
         df = pd.concat(dflist)
         return df

--- a/scripts/paint_utils.py
+++ b/scripts/paint_utils.py
@@ -3,6 +3,7 @@ import pandas as pd
 
 from io_utils import read_csvs_with_chunksize
 
+
 def load_single_cell_compartment_csv(compartment_dir, compartment, metadata_cols):
     """
     Load and process columns for CellProfiler output data

--- a/scripts/paint_utils.py
+++ b/scripts/paint_utils.py
@@ -1,6 +1,7 @@
 import pathlib
 import pandas as pd
 
+from io_utils import read_csvs_with_chunksize
 
 def load_single_cell_compartment_csv(compartment_dir, compartment, metadata_cols):
     """
@@ -21,7 +22,7 @@ def load_single_cell_compartment_csv(compartment_dir, compartment, metadata_cols
     compartment_file = pathlib.Path(compartment_dir, f"{compartment}.csv")
 
     # Load compartment data
-    compartment_df = pd.read_csv(compartment_file)
+    compartment_df = read_csvs_with_chunksize(compartment_file)
     compartment_df.columns = [f"{compartment}_{x}" for x in compartment_df.columns]
 
     # Identify and rename metadata_cols


### PR DESCRIPTION
We have seen in pycytominer that using a chunksize parameter on pandas.read_sql averts runaway memory consumption errors; we are hoping doing so here for read_csv has the same effect!

A new `read_csvs_with_chunksize` function is added her to `io_utils`, and all other `pd.read_csv` calls are replaced with it.  Right now we are not actually configuring what size chunks to use anywhere, but I've left it configurable in case in future user testing we find it works better with different sizes for different calls.

I've also explicitly not done any error handling other than raising, simply because in various places in the script sometimes even the same error class is sometimes breaking for the recipe and sometimes not, and I thought we should continue to just support the logic where it currently is.