### PR TITLE
Handle missing metadata

### DIFF
--- a/0.preprocess-sites/2.process-cells.py
+++ b/0.preprocess-sites/2.process-cells.py
@@ -269,18 +269,31 @@ for data_split_site in site_info_dict:
                     "Output files likely exist. If they do, NOT overwriting..."
                 )
                 logging.warning("Output files likely exist. NOT Overwriting.")
-        os.makedirs(output_folder, exist_ok=True)
+        if len(metadata_df) > 0 or len(cell_count_df) > 0:
+            os.makedirs(output_folder, exist_ok=True)
+        else:
+            print(f"Metadata and Cell Count files empty. Nothing to save for {site}")
+            logging.warning(f"Metadata and Cell Count files empty. Nothing to save for {site}")
+            continue
 
         meta_output_file = pathlib.Path(output_folder, f"metadata_{site}.tsv.gz")
         count_output_file = pathlib.Path(output_folder, f"cell_counts_{site}.tsv")
 
         # Save files
         if check_if_write(meta_output_file, force):
-            metadata_df.to_csv(meta_output_file, sep="\t", index=False)
+            if len(metadata_df) > 0:
+                metadata_df.to_csv(meta_output_file, sep="\t", index=False)
+            else:
+                print(f"Metadata file empty. Nothing to save for {site}")
+                logging.warning(f"Metadata file empty. Nothing to save for {site}")
         if check_if_write(count_output_file, force):
-            cell_count_df.to_csv(
-                count_output_file, sep="\t", index_label="Cell_Quality"
-            )
+            if len(cell_count_df) > 0:
+                cell_count_df.to_csv(
+                    count_output_file, sep="\t", index_label="Cell_Quality"
+                )
+            else:
+                print(f"Cell Count file empty. Nothing to save for {site}")
+                logging.warning(f"Cell Count file empty. Nothing to save for {site}")
 
 print("Finished 2.process-cells.")
 logging.info(f"Finished 2.process-cells.")

--- a/0.preprocess-sites/4.image-and-segmentation-qc.py
+++ b/0.preprocess-sites/4.image-and-segmentation-qc.py
@@ -479,6 +479,7 @@ if all(x in image_df.columns.tolist() for x in cp_sat_cols):
         temp = image_df[image_df[col] > 1]
         cp_sat_df = cp_sat_df.append(temp)
     if len(cp_sat_df) != 0:
+        cp_sat_df = cp_sat_df.drop_duplicates()
         cp_sat_df.loc[:, "Fails_CP_Sat"] = "Fails"
 
 # Create df of sites that fail BC saturation
@@ -487,21 +488,24 @@ if all(x in image_df.columns.tolist() for x in bc_sat_cols):
         temp = image_df[image_df[col] > 0.2]
         bc_sat_df = bc_sat_df.append(temp)
     if len(bc_sat_df) != 0:
+        bc_sat_df = bc_sat_df.drop_duplicates()
         bc_sat_df.loc[:, "Fails_BC_Sat"] = "Fails"
+
+idcols = list(image_cols["plate"], image_cols["well"], image_cols["site"])
 
 if len(cp_sat_df) > 0 and len(bc_sat_df) > 0:
     sat_df = (
         cp_sat_df.set_index("Metadata_Site_Full")
-        .combine_first(bc_sat_df.set_index("Metadata_Site_Full"))
+        .combine_first(bc_sat_df.set_index(idcols))
         .reset_index()
     )
-    addn_cols = ["Metadata_Site_Full", "Fails_CP_Sat", "Fails_BC_Sat"]
+    addn_cols = idcols + ["Fails_CP_Sat", "Fails_BC_Sat"]
 elif len(cp_sat_df) > 0:
     sat_df = cp_sat_df
-    addn_cols = ["Metadata_Site_Full", "Fails_CP_Sat"]
+    addn_cols = idcols + ["Fails_CP_Sat"]
 elif len(bc_sat_df) > 0:
     sat_df = bc_sat_df
-    addn_cols = ["Metadata_Site_Full", "Fails_BC_Sat"]
+    addn_cols = idcols + ["Fails_BC_Sat"]
 
 if not sat_df.empty:
     sat_df_cols = cp_sat_cols + bc_sat_cols + addn_cols

--- a/1.generate-profiles/0.merge-single-cells.py
+++ b/1.generate-profiles/0.merge-single-cells.py
@@ -162,9 +162,14 @@ for data_split_site in site_info_dict:
 
         # Load cell metadata after cell quality determined in 0.preprocess-sites
         metadata_file = pathlib.Path(site_metadata_dir, f"metadata_{site}.tsv.gz")
-        metadata_df = read_csvs_with_chunksize(metadata_file, sep="\t").query(
-            f"{cell_quality_col} in @cell_filter"
-        )
+        try:
+            metadata_df = read_csvs_with_chunksize(metadata_file, sep="\t").query(
+                f"{cell_quality_col} in @cell_filter"
+            )
+        except:
+            print(f"Error loading metadata file for {site}. Skipping.")
+            logging.info(f"Error loading metadata file for {site}. Skipping.")
+            continue
 
         if sanitize_genes:
             metadata_df = sanitize_gene_col(metadata_df, gene_col, control_barcodes)

--- a/1.generate-profiles/0.merge-single-cells.py
+++ b/1.generate-profiles/0.merge-single-cells.py
@@ -173,6 +173,8 @@ for data_split_site in site_info_dict:
 
         if sanitize_genes:
             metadata_df = sanitize_gene_col(metadata_df, gene_col, control_barcodes)
+            if len(metadata_df) == 0:
+                continue
 
         # Load csv files for prespecified compartments
         compartment_csvs = {}

--- a/scripts/profile_utils.py
+++ b/scripts/profile_utils.py
@@ -14,7 +14,10 @@ def sanitize_gene_col(metadata_df, gene_col, control_barcodes):
     The same metadata dataframe as input with a sanitized column
     """
     genes = metadata_df.loc[:, gene_col].squeeze()
-    genes = [x.split("_")[0] if x not in control_barcodes else x for x in genes]
+    if len(genes) > 0:
+        genes = [x.split("_")[0] if x not in control_barcodes else x for x in genes]
 
-    metadata_df.loc[:, gene_col] = genes
-    return metadata_df.copy()
+        metadata_df.loc[:, gene_col] = genes
+        return metadata_df.copy()
+    else:
+        return metadata_df


### PR DESCRIPTION
Should fix https://github.com/broadinstitute/CP186-A549-WG/issues/4

Recipe errored at 1./0.merge-single-cells because a site had foci but no cells. So metadata_{site}.csv made during 0./2.process-cells was empty but a non-empty csv was expected in 1./0.merge-single-cells because there was site information in the input_spotdir.

This PR changes: 
- 0./2.process-cells to not save empty csvs
- 1./0.merge-single-cells to skip a site with empty or missing metadata_{site}.csv 
- sanitize_gene_col() to avoid errors trying to process an empty metadata_df